### PR TITLE
add another numpy version constraint

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -5,3 +5,4 @@ python = ">=3.6,<=3.10"
 
 [pip.deps]
 ehtim = ""
+numpy = "<=1.24"


### PR DESCRIPTION
Otherwise, conda installs the requested 1.24, but then pip ignores this restriction – it uninstalls 1.24 and installs 2.0. Ehtim doesn't work with numpy 2.0.